### PR TITLE
feat(api): añadir fecha_comprobante al modelo de respuesta

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -51,6 +51,7 @@ factura_response_model = afipws_ns.model('FacturaResponse', {
     'cae': fields.String(description='Número de CAE'),
     'vencimiento_cae': fields.String(description='Fecha de vencimiento del CAE'),
     'numero_comprobante': fields.Integer(description='Número de comprobante'),
+    'fecha_comprobante': fields.String(description='Fecha del comprobante'),
     'asociado_tipo_afip': fields.Integer(description='Tipo de comprobante asociado'),
     'asociado_punto_venta': fields.Integer(description='Punto de venta del comprobante asociado'),
     'asociado_numero_comprobante': fields.Integer(description='Número de comprobante asociado'),


### PR DESCRIPTION
## Descripción
Este Pull Request introduce el campo `fecha_comprobante` en el modelo de respuesta de la API (`FacturaResponse`), enriqueciendo la información devuelta al consultar una factura. El objetivo es proporcionar al cliente la fecha de emisión del comprobante, un dato clave que faltaba en la implementación anterior.

Este cambio resuelve el issue #46.

## Cambios Realizados
- [x] Se ha añadido el campo `fecha_comprobante: fields.String` al modelo `FacturaResponse` en `app/routes.py`.

## Impacto Potencial
- [ ] No se prevé ningún impacto negativo. Este es un cambio aditivo y no rompe la compatibilidad con las integraciones existentes.
- [ ] Los clientes de la API ahora pueden recibir y utilizar el nuevo campo `fecha_comprobante`.

## Verificación
Para verificar los cambios:
1.  Ejecutar la aplicación localmente.
2.  Realizar una petición `GET` al endpoint `/api/afipws/consulta_comprobante` con los parámetros necesarios.
3.  Verificar que la respuesta JSON ahora incluye el campo `fecha_comprobante` con un valor válido.

## Notas Adicionales
No hay notas adicionales.
