### PR TITLE
feat(facturacion): agregar Importe Exento (imp_op_ex), actualizar v2.5.0

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -75,6 +75,7 @@ jobs:
               <div id="architecture" class="section"></div>
               <div id="request-flow" class="section"></div>
               <div id="facturador-flow" class="section"></div>
+              <div id="export-flow" class="section"></div>
               <div id="dependencies" class="section">
                   <h2>🐍 Dependencias de Python</h2>
                   <pre id="dependency-tree-content">Cargando...</pre>
@@ -143,6 +144,15 @@ jobs:
                   .then(data => {
                       const container = document.getElementById('facturador-flow');
                       container.innerHTML = '<h2>🧾 Diagrama de Secuencia: Emisión de Factura</h2><div class="mermaid">' + data + '</div>';
+                      mermaid.init(undefined, container.querySelector('.mermaid'));
+                  });
+
+              // --- Export Flow Diagram ---
+              fetch('diagrams/export-flow.mmd')
+                  .then(response => response.text())
+                  .then(data => {
+                      const container = document.getElementById('export-flow');
+                      container.innerHTML = '<h2>🌍 Diagrama de Secuencia: Facturación de Exportación</h2><div class="mermaid">' + data + '</div>';
                       mermaid.init(undefined, container.querySelector('.mermaid'));
                   });
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [2.5.0] - 2026-07-08
+
+### Nuevas características
+- **Importe Exento**: Se agregó soporte para el campo `exento` (importe exento) en la facturación electrónica, mapeándolo al campo `imp_op_ex` del comprobante AFIP.
+
+### Mejoras
+- **Documentación Swagger**: Se añadió el campo `exento` al modelo de datos de facturación con descripción y ejemplo.
+- **Documentación API**: Se actualizó la documentación del README para incluir el nuevo campo `exento`.
+
+### Cambios técnicos
+- Actualizado `app/factura_electronica.py` para incluir `imp_op_ex` en la creación del comprobante.
+- Actualizado `app/routes.py` para exponer el campo `exento` en el modelo Swagger.
+- Actualizada versión de la API en `app/service.py` a 2.5.0.
+
 ## [2.4.0] - 2026-01-01
 
 ### Nuevas características

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyafipws_endpoint_consul
 
-[![Build and Push Docker Image](https://github.com/dqmdz/pyafipws_endpoint_eureka/actions/workflows/deploy.yml/badge.svg)](https://github.com/dqmdz/pyafipws_endpoint_eureka/actions/workflows/deploy.yml)
+[![Build and Push Docker Image](https://github.com/dqmdz/pyafipws_endpoint_discovery/actions/workflows/deploy.yml/badge.svg)](https://github.com/dqmdz/pyafipws_endpoint_discovery/actions/workflows/deploy.yml)
 [![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/downloads/release/python-3130/)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
@@ -118,6 +118,7 @@ Emite un comprobante electrónico.
 - `id_condicion_iva`: ID de condición IVA del receptor
 
 **Campos opcionales:**
+- `exento`: Importe exento
 - `neto`: Importe neto gravado
 - `iva`: Importe IVA 21%
 - `neto105`: Importe neto gravado 10.5%
@@ -212,6 +213,7 @@ curl -X POST "http://localhost:5086/api/afipws/facturador" \
     "documento": "20123456789",
     "total": 1210.0,
     "id_condicion_iva": 1,
+    "exento": 0.0,
     "neto": 1000.0,
     "iva": 210.0
   }'

--- a/app/factura_electronica.py
+++ b/app/factura_electronica.py
@@ -118,6 +118,7 @@ def facturar(json_data: Dict[str, Any], production: bool = False) -> Dict[str, A
             imp_total=json_data.get("total"),
             imp_neto=round(json_data.get("neto", 0) + json_data.get("neto105", 0), 2),
             imp_iva=round(json_data.get("iva", 0) + json_data.get("iva105", 0), 2),
+            imp_op_ex=round(json_data.get("exento", 0), 2),
             asociado_tipo_afip=json_data.get("asociado_tipo_afip", None),
             asociado_punto_venta=json_data.get("asociado_punto_venta", None),
             asociado_numero_comprobante=json_data.get("asociado_numero_comprobante", None),

--- a/app/routes.py
+++ b/app/routes.py
@@ -22,6 +22,7 @@ factura_model = afipws_ns.model('Factura', {
     'total': fields.Float(required=True, description='Importe total', example=1210.0),
     'id_condicion_iva': fields.Integer(required=True, description='ID de condición IVA del receptor', example=1),
     'neto': fields.Float(description='Importe neto gravado', example=1000.0),
+    'exento': fields.Float(description='Importe exento', example=0.0),
     'iva': fields.Float(description='Importe IVA 21%', example=210.0),
     'neto105': fields.Float(description='Importe neto gravado 10.5%', example=0.0),
     'iva105': fields.Float(description='Importe IVA 10.5%', example=0.0),

--- a/app/service.py
+++ b/app/service.py
@@ -81,7 +81,7 @@ def create_app(config: Dict[str, Any] = None) -> Flask:
     # Configurar Flask-RESTX con Swagger
     api = Api(
         app,
-        version='2.4.0',
+        version='2.5.0',
         title='pyafipws API',
         description='API REST para emisión de comprobantes electrónicos AFIP',
         doc='/swagger/',


### PR DESCRIPTION
Closes #53

## Descripción

Se agrega soporte para el campo **Importe Exento (`exento` → `imp_op_ex`)** en la facturación electrónica AFIP y se actualiza la versión de la API a **2.5.0**.

## Cambios Realizados

- **`app/factura_electronica.py`**: Mapeo del campo `exento` al campo `imp_op_ex` del comprobante AFIP en `facturar()`.
- **`app/routes.py`**: Exposición del campo `exento` en el modelo Swagger de la API.
- **`app/service.py`**: Actualización de versión de API de `2.4.0` a `2.5.0`.
- **`README.md`**: Corrección de URLs de badges y documentación del nuevo campo `exento`.
- **`CHANGELOG.md`**: Registro de cambios para la versión `2.5.0`.
- **`.github/workflows/generate-docs.yml`**: Inclusión del diagrama de secuencia de Facturación de Exportación.

## Verificación

- [ ] Los tests existentes pasan correctamente.
- [ ] El campo `exento` es opcional y por defecto se envía como `0.0` a AFIP (backwards-compatible).
- [ ] La documentación Swagger refleja el nuevo campo.
- [ ] El workflow de generación de documentación incluye el diagrama de exportación.
