### PR TITLE
feat(cert): add certificate verification endpoint with WSAA auth

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -76,6 +76,7 @@ jobs:
               <div id="request-flow" class="section"></div>
               <div id="facturador-flow" class="section"></div>
               <div id="export-flow" class="section"></div>
+              <div id="cert-verify-flow" class="section"></div>
               <div id="dependencies" class="section">
                   <h2>🐍 Dependencias de Python</h2>
                   <pre id="dependency-tree-content">Cargando...</pre>
@@ -156,6 +157,15 @@ jobs:
                       mermaid.init(undefined, container.querySelector('.mermaid'));
                   });
           
+              // --- Cert Verify Flow Diagram ---
+              fetch('diagrams/cert-verify-flow.mmd')
+                  .then(response => response.text())
+                  .then(data => {
+                      const container = document.getElementById('cert-verify-flow');
+                      container.innerHTML = '<h2>🔒 Diagrama de Secuencia: Verificación de Certificado</h2><div class="mermaid">' + data + '</div>';
+                      mermaid.init(undefined, container.querySelector('.mermaid'));
+                  });
+
               // --- Milestones ---
               let milestonesHTML = '<h2>🎯 Milestones</h2>';
               milestonesData.forEach(milestone => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [2.6.0] - 2026-07-08
+
+### Nuevas características
+- **Verificación de Certificados AFIP**: Se agregó un nuevo endpoint `GET /api/afipws/certificado/verificar` que permite:
+  - Validación local del certificado X.509 (fechas de validez, extracción de CUIT, emisor y sujeto).
+  - Verificación online de autenticación WSAA contra AFIP (production/homologación).
+  - Integración con OpenTelemetry para trazabilidad completa.
+- **Endpoint de Verificación de Certificados**: Nuevo recurso REST (`CertificadoVerificarResource`) con modelo de respuesta `CertCheckResponse` documentado en Swagger.
+
+### Cambios técnicos
+- Actualizado `app/routes.py` con nuevo endpoint y modelo Swagger.
+- Añadidas importaciones de `cryptography.x509`, `pyafipws.wsaa.WSAA` y constantes `URL_WSAA_HOMO`/`URL_WSAA_PROD`.
+- Actualizada versión de la API en `app/service.py` a 2.6.0.
+- Actualizada versión del recurso OpenTelemetry en `app/otel_setup.py`.
+
 ## [2.5.0] - 2026-07-08
 
 ### Nuevas características

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyafipws_endpoint_consul
+# pyafipws_endpoint_discovery
 
 [![Build and Push Docker Image](https://github.com/dqmdz/pyafipws_endpoint_discovery/actions/workflows/deploy.yml/badge.svg)](https://github.com/dqmdz/pyafipws_endpoint_discovery/actions/workflows/deploy.yml)
 [![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/downloads/release/python-3130/)
@@ -28,7 +28,7 @@ Servicio REST basado en [pyafipws v2025.05.05](https://github.com/dqmdz/pyafipws
 
 ## Requisitos
 
-- Python 3.11
+- Python 3.11+ (3.12 y 3.13 también soportados)
 - Docker y Docker Compose
 - Certificados AFIP válidos (`.crt` y `.key`)
 - CUIT válido para facturación
@@ -56,7 +56,7 @@ Servicio REST basado en [pyafipws v2025.05.05](https://github.com/dqmdz/pyafipws
 ### Desarrollo local
 
 ```bash
-docker-compose -f docker-compose.yml.example up
+docker-compose up
 ```
 
 ### Producción
@@ -100,8 +100,6 @@ La documentación Swagger incluye:
 - Modelos de datos con ejemplos
 - Interfaz interactiva para probar los endpoints
 - Códigos de respuesta y manejo de errores
-
-📖 **Guía completa de Swagger**: [docs/SWAGGER_GUIDE.md](docs/SWAGGER_GUIDE.md)
 
 ## API Endpoints
 
@@ -194,11 +192,33 @@ Consulta un comprobante electrónico ya emitido.
 
 Endpoint de prueba para verificar el estado del servicio.
 
+### GET /api/afipws/certificado/verificar
+
+Verifica la validez local del certificado AFIP y la autenticación online contra WSAA.
+
+**Respuesta Exitosa (200 OK):**
+```json
+{
+  "valido": true,
+  "cuit": "CUIT 20XXXXXXXX9",
+  "not_before": "2024-01-01T00:00:00",
+  "not_after": "2025-12-31T23:59:59",
+  "dias_restantes": 180,
+  "emisor": "CN=AFIP CA",
+  "sujeto": "CN=...",
+  "autenticacion_afip_ok": true,
+  "error_afip": null
+}
+```
+
 ## Ejemplo de uso con curl
 
 ```bash
 # Probar el endpoint de test
 curl -X GET "http://localhost:5086/api/afipws/test"
+
+# Verificar el estado del certificado AFIP
+curl -X GET "http://localhost:5086/api/afipws/certificado/verificar"
 
 # Consultar un comprobante existente
 curl -X GET "http://localhost:5086/api/afipws/consulta_comprobante?tipo_cbte=6&punto_vta=34&cbte_nro=100"
@@ -245,11 +265,6 @@ curl -X POST "http://127.0.0.1:5000/api/afipws/facturador_exportacion" \
     "tipo_expo": 1
   }'
 ```
-
-## Ejemplos y Documentación
-
-- 📚 [Guía de Swagger](docs/SWAGGER_GUIDE.md) - Documentación completa de la API
-- 🚀 [Ejemplo de uso](examples/api_usage.py) - Script de ejemplo para probar la API
 
 ## Licencia
 

--- a/app/otel_setup.py
+++ b/app/otel_setup.py
@@ -38,7 +38,7 @@ def setup_otel() -> Optional[trace.Tracer]:
         # Configurar el recurso con información del servicio
         resource = Resource.create({
             "service.name": "pyafipws-service",
-            "service.version": "1.0.0",
+            "service.version": "2.6.0",
             "deployment.environment": "production" if os.getenv('PRODUCTION', 'FALSE').upper() == 'TRUE' else "development"
         })
         

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,10 +2,14 @@ import json
 from flask import request
 from flask_restx import Namespace, Resource, fields
 from app.logger_setup import logger
-from app.factura_electronica import facturar, consultar_comprobante
+from app.factura_electronica import facturar, consultar_comprobante, URL_WSAA_HOMO, URL_WSAA_PROD
 from app.factura_exportacion import facturar_exportacion
 from app.otel_setup import get_tracer
 from typing import Dict
+from cryptography import x509
+from datetime import datetime, timezone
+from pyafipws.wsaa import WSAA
+
 
 # Crear namespace para Flask-RESTX
 afipws_ns = Namespace('afipws', description='Operaciones de facturación AFIP')
@@ -140,6 +144,111 @@ class TestResource(Resource):
         else:
             logger.info("test")
             return {"test": "ok"}
+
+
+cert_check_response_model = afipws_ns.model('CertCheckResponse', {
+    'valido': fields.Boolean(description='Indica si el certificado es válido actualmente (localmente)'),
+    'cuit': fields.String(description='CUIT extraído del certificado'),
+    'not_before': fields.String(description='Fecha de inicio de validez'),
+    'not_after': fields.String(description='Fecha de vencimiento'),
+    'dias_restantes': fields.Integer(description='Días restantes hasta la expiración'),
+    'emisor': fields.String(description='Emisor del certificado (CA)'),
+    'sujeto': fields.String(description='Sujeto del certificado'),
+    'autenticacion_afip_ok': fields.Boolean(description='Indica si la autenticación WSAA con AFIP fue exitosa (verificación online)'),
+    'error_afip': fields.String(description='Mensaje de error si la autenticación con AFIP falló')
+})
+
+
+@afipws_ns.route('/certificado/verificar')
+class CertificadoVerificarResource(Resource):
+    @afipws_ns.doc('verificar_certificado')
+    @afipws_ns.marshal_with(cert_check_response_model)
+    def get(self):
+        """Verifica la validez local y la autenticación ante AFIP del certificado configurado."""
+        tracer = get_tracer()
+        
+        def _verificar():
+            cert_path = _afip_config.get('cert_path')
+            privatekey_path = _afip_config.get('privatekey_path')
+            production = _afip_config.get('production', False)
+            
+            # 1. Validación Local del Certificado
+            try:
+                with open(cert_path, "rb") as f:
+                    cert_data = f.read()
+                
+                cert = x509.load_pem_x509_certificate(cert_data)
+                
+                # Obtener fechas de validez (soportando versiones de cryptography con _utc)
+                not_before = getattr(cert, 'not_valid_before_utc', cert.not_valid_before)
+                not_after = getattr(cert, 'not_valid_after_utc', cert.not_valid_after)
+                
+                # Asegurar timezone-aware para la comparación si corresponde
+                now = datetime.now(timezone.utc) if not_before.tzinfo else datetime.now()
+                
+                valido_local = not_before <= now <= not_after
+                dias_restantes = (not_after - now).days
+                
+                # Extraer CUIT y detalles
+                sujeto_str = cert.subject.rfc4514_string()
+                emisor_str = cert.issuer.rfc4514_string()
+                
+                # Intentar extraer el CUIT de los atributos del Subject
+                cuit_extraido = "No encontrado"
+                for attribute in cert.subject:
+                    oid_str = attribute.oid.dotted_string
+                    # OID 2.5.4.5 es serialNumber (donde AFIP suele guardar el CUIT como CUIT 20XXXXXXXX9)
+                    if oid_str == "2.5.4.5":
+                        cuit_extraido = attribute.value
+                        break
+                    # OID 2.5.4.3 es commonName
+                    elif oid_str == "2.5.4.3" and "CUIT" in attribute.value:
+                        cuit_extraido = attribute.value
+                        break
+                        
+            except Exception as e:
+                logger.error(f"Error al analizar el certificado localmente: {e}")
+                afipws_ns.abort(500, f"Error al leer/analizar el archivo de certificado: {str(e)}")
+
+            # 2. Validación Online (Autenticación WSAA ante AFIP)
+            autenticacion_afip_ok = False
+            error_afip = None
+            
+            try:
+                URL_WSAA = URL_WSAA_PROD if production else URL_WSAA_HOMO
+                wsaa = WSAA()
+                # Intenta obtener un Ticket de Acceso (TA) para el servicio 'wsfe'
+                ta = wsaa.Autenticar(
+                    "wsfe", cert_path, privatekey_path, wsdl=URL_WSAA, cache="", debug=False
+                )
+                if ta:
+                    autenticacion_afip_ok = True
+            except Exception as auth_error:
+                logger.warning(f"Fallo en la autenticación online con AFIP: {auth_error}")
+                error_afip = str(auth_error)
+
+            return {
+                'valido': valido_local,
+                'cuit': cuit_extraido,
+                'not_before': not_before.isoformat(),
+                'not_after': not_after.isoformat(),
+                'dias_restantes': dias_restantes,
+                'emisor': emisor_str,
+                'sujeto': sujeto_str,
+                'autenticacion_afip_ok': autenticacion_afip_ok,
+                'error_afip': error_afip
+            }
+
+        if tracer:
+            with tracer.start_as_current_span("verificar_certificado_endpoint") as span:
+                span.set_attribute("endpoint", "/certificado/verificar")
+                span.set_attribute("method", "GET")
+                res = _verificar()
+                span.set_attribute("cert.valido_local", res['valido'])
+                span.set_attribute("cert.autenticacion_afip_ok", res['autenticacion_afip_ok'])
+                return res
+        else:
+            return _verificar()
 
 
 @afipws_ns.route('/facturador_exportacion')

--- a/app/service.py
+++ b/app/service.py
@@ -81,7 +81,7 @@ def create_app(config: Dict[str, Any] = None) -> Flask:
     # Configurar Flask-RESTX con Swagger
     api = Api(
         app,
-        version='2.5.0',
+        version='2.6.0',
         title='pyafipws API',
         description='API REST para emisión de comprobantes electrónicos AFIP',
         doc='/swagger/',

--- a/docs/diagrams/cert-verify-flow.mmd
+++ b/docs/diagrams/cert-verify-flow.mmd
@@ -1,0 +1,41 @@
+sequenceDiagram
+    participant C as Cliente
+    participant R as app.routes
+    participant CRYPTO as cryptography
+    participant WSAA as pyafipws.wsaa
+    participant A as AFIP
+
+    C->>R: GET /api/afipws/certificado/verificar
+    activate R
+
+    Note over R: 1. Validación Local del Certificado
+    R->>CRYPTO: load_pem_x509_certificate(cert_data)
+    activate CRYPTO
+    CRYPTO-->>R: Certificado X.509 parseado
+    deactivate CRYPTO
+
+    Note over R: Verificar not_before / not_after
+    Note over R: Extraer CUIT (OID 2.5.4.5)
+    Note over R: Extraer emisor y sujeto
+
+    alt Certificado Válido (fechas correctas)
+        Note over R: valido = True, dias_restantes calculados
+
+        Note over R: 2. Validación Online (WSAA)
+        R->>WSAA: Autenticar("wsfe", cert_path, key_path, wsdl)
+        activate WSAA
+        WSAA->>A: Solicitar Ticket de Acceso (TA)
+        A-->>WSAA: Token de Acceso
+        WSAA-->>R: autenticacion_afip_ok = True
+        deactivate WSAA
+    else Certificado Vencido o Inválido
+        Note over R: valido = False
+    end
+
+    alt Error de Autenticación AFIP
+        Note over R: error_afip = mensaje de error
+        Note over R: autenticacion_afip_ok = False
+    end
+
+    R-->>C: {valido, cuit, not_before, not_after, ...}
+    deactivate R

--- a/docs/diagrams/facturador-flow.mmd
+++ b/docs/diagrams/facturador-flow.mmd
@@ -57,7 +57,6 @@ sequenceDiagram
     P-->>FE: wsfex.CAE, wsfex.FchVencCAE
     deactivate P
     
-    deactivate FE
     FE-->>R: JSON con CAE y datos exportación
     deactivate FE
     R-->>C: JSON Response Exportación


### PR DESCRIPTION
## Descripción

Se implementa un nuevo endpoint `GET /api/afipws/certificado/verificar` que realiza una verificación dual del certificado AFIP configurado: validación local del X.509 (fechas, CUIT, emisor/sujeto) y autenticación online contra WSAA (production/homologación).

## Cambios Realizados

- **Nuevo endpoint**: `CertificadoVerificarResource` en `app/routes.py` con modelo Swagger `CertCheckResponse`.
- **Validación local**: Parsing del certificado PEM con `cryptography.x509`, extracción de fechas de validez, CUIT (OID 2.5.4.5/2.5.4.3), emisor y sujeto.
- **Validación online**: Autenticación WSAA contra AFIP vía `pyafipws.wsaa.WSAA.Autenticar()` para el servicio `wsfe`.
- **Observabilidad**: Trazabilidad OpenTelemetry completa con span dedicado y atributos de resultado.
- **Documentación**: Nuevo diagrama de secuencia Mermaid (`docs/diagrams/cert-verify-flow.mmd`) renderizado en la documentación generada.
- **CI/CD**: Actualizado `generate-docs.yml` para incluir el nuevo diagrama.
- **Versión**: Bump a `2.6.0` en `app/service.py`, `app/otel_setup.py` y `CHANGELOG.md`.
- **Corrección**: Eliminado `deactivate FE` huérfano en `docs/diagrams/facturador-flow.mmd`.
- **Docs**: Actualizado `README.md` con el nuevo endpoint, corrección del nombre del proyecto y simplificación de referencias a documentación.

## Verificación

- [ ] Ejecutar `pytest` para confirmar que no se rompen tests existentes.
- [ ] Probar endpoint localmente con un certificado válido: `curl -X GET "http://localhost:5086/api/afipws/certificado/verificar"`
- [ ] Verificar respuesta 200 con estructura `CertCheckResponse` completa.
- [ ] Verificar respuesta 500 con certificado inválido o inexistente.
- [ ] Confirmar que el diagrama `cert-verify-flow.mmd` se renderiza correctamente en la docs generada.
